### PR TITLE
feat: aside 생성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import { RouterProvider } from "react-router-dom";
+import Aside from "@components/Aside";
 import router from "./router";
 const App = () => {
   return (
-    <div>
+    <>
+      <Aside />
       <RouterProvider router={router} />
-    </div>
+    </>
   );
 };
 export default App;

--- a/src/components/Aside.tsx
+++ b/src/components/Aside.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+const Aside = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [subMenuIsOpen, setSubMenuIsOpen] = useState(false);
+  return (
+    <aside className="drawer-side h-screen w-56 bg-slate-300">
+      <h1 className="ml-4 text-3xl">Jobkok Logo</h1>
+      <ul className="menu bg-base-100 bg-transparent p-4 text-base-content">
+        {ASIDE_MENU.map((menu, i) =>
+          menu === "인재풀" ? (
+            <li key={i} className="items-start">
+              <li onClick={() => setIsOpen(!isOpen)}>{menu}</li>
+              {isOpen ? (
+                <li
+                  className="items-start bg-transparent text-sm"
+                  onClick={() => setSubMenuIsOpen(!subMenuIsOpen)}
+                >
+                  - 인재관리
+                  {subMenuIsOpen ? (
+                    <li className="items-start text-xs">- 채용 진행 현황</li>
+                  ) : null}
+                </li>
+              ) : null}
+            </li>
+          ) : (
+            <li key={i}>
+              <a>{menu}</a>
+            </li>
+          ),
+        )}
+      </ul>
+    </aside>
+  );
+};
+export default Aside;
+
+const ASIDE_MENU = [
+  "인재풀",
+  "폼 링크 관리",
+  "단체 알림 센터",
+  "기업 정보 변경",
+];

--- a/src/components/Aside.tsx
+++ b/src/components/Aside.tsx
@@ -12,15 +12,20 @@ const Aside = () => {
             <li key={i} className="items-start">
               <li onClick={() => setIsOpen(!isOpen)}>{menu}</li>
               {isOpen ? (
-                <li
-                  className="items-start bg-transparent text-sm"
-                  onClick={() => setSubMenuIsOpen(!subMenuIsOpen)}
-                >
-                  - 인재관리
-                  {subMenuIsOpen ? (
-                    <li className="items-start text-xs">- 채용 진행 현황</li>
-                  ) : null}
-                </li>
+                <>
+                  <li
+                    className="items-start bg-transparent text-sm"
+                    onClick={() => setSubMenuIsOpen(!subMenuIsOpen)}
+                  >
+                    - 인재관리
+                    {subMenuIsOpen ? (
+                      <li className="items-start text-xs">- 채용 진행 현황</li>
+                    ) : null}
+                  </li>
+                  <li className="items-start bg-transparent text-sm">
+                    - 보류 인재 보관함
+                  </li>
+                </>
               ) : null}
             </li>
           ) : (

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,15 +1,4 @@
-import { ReactComponent as Test } from "@/svg/test.svg";
-import Button from "@components/Common/Button";
 const Home = () => {
-  return (
-    <div className="text-xl font-extrabold text-rose-300">
-      Hello World
-      <br />
-      <Button />
-      <div>
-        <Test className="h-6 w-6" />
-      </div>
-    </div>
-  );
+  return <></>;
 };
 export default Home;


### PR DESCRIPTION
## 작업 개요 (이슈 번호)

Close #22 

## 작업 내용 (변경 사항)
- [x] 화면 우측에 고정되어 있는 aside 마크업
- [x] 메뉴는 닫혀진 상태로 있으며 클릭시 하위 메뉴 오픈

## 리뷰 요청 사항
- 아직 정확한 디자인이 나오지 않았기 때문에 배경 색이나 크기 등등은 임의로 지정하였습니다.
- 인재풀 메뉴를 눌렀을 시 나타나는 하위 메뉴는 `useState` hook을 사용하여 상태로 관리하였습니다.
- 메뉴 리스트는 추후 유지 보수가 쉽도록 상수(ASIDE_MENU)로 관리합니다. 다른 컴포넌트에서는 사용할 일이 없을 것 같다고 판단하여 파일 분리하지 않았습니다. 

## sample
![잡콕 aside](https://user-images.githubusercontent.com/103406196/227452599-1a8176b5-4cb6-4af7-9920-abb89339f19e.gif)
