### PR TITLE
feat: 미인증 에러(`400`) 해결을 위한 axios interceptors 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,16 +2,6 @@ import type { AxiosResponse } from "axios";
 import { AxiosError } from "axios";
 import { client } from "./axios";
 
-client.interceptors.request.use((config) => {
-  const { accessToken, refreshToken } = JSON.parse(
-    JSON.parse(localStorage.getItem("persist:root")!).auth,
-  );
-  if (accessToken) {
-    config.headers.Authorization = `Bearer ${accessToken}`;
-  }
-  return config;
-});
-
 // 로그인
 export const postSignIn = async (useremail: string, password: string) => {
   try {
@@ -21,7 +11,7 @@ export const postSignIn = async (useremail: string, password: string) => {
     });
     localStorage.clear();
     if (data.state === 200) {
-      localStorage.setItem("token", data.data.accessToken);
+      localStorage.setItem("token", JSON.stringify(data.data));
     }
     return data;
   } catch (error) {

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -6,3 +6,42 @@ const config: AxiosRequestConfig = {
 };
 
 export const client = axios.create(config);
+
+const { accessToken, refreshToken } = JSON.parse(
+  localStorage.getItem("token") || "{}",
+);
+client.interceptors.request.use((config) => {
+  if (!config.headers) return config;
+
+  if (accessToken !== null) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
+});
+
+client.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const { config, response } = error;
+
+    const status = response.status;
+
+    if (status === 400) {
+      const res = await axios({
+        method: "POST",
+        url: "https://jobkok.shop/auth/reissue",
+        headers: {
+          Authorization: `Bearer ${refreshToken}`,
+        },
+      });
+
+      if (res.status === 200) {
+        localStorage.setItem("token", JSON.stringify(res.data.data));
+        config.headers.Authorization = `Bearer ${res.data.data.accessToken}`;
+      } else {
+        return Promise.reject(error);
+      }
+    }
+    return axios(config);
+  },
+);

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -7,11 +7,11 @@ const config: AxiosRequestConfig = {
 
 export const client = axios.create(config);
 
-const { accessToken, refreshToken } = JSON.parse(
-  localStorage.getItem("token") || "{}",
-);
 client.interceptors.request.use((config) => {
+  const { accessToken } = JSON.parse(localStorage.getItem("token") || "{}");
   if (!config.headers) return config;
+
+  console.log(config);
 
   if (accessToken !== null) {
     config.headers.Authorization = `Bearer ${accessToken}`;
@@ -22,12 +22,14 @@ client.interceptors.request.use((config) => {
 client.interceptors.response.use(
   (response) => response,
   async (error) => {
+    const { refreshToken } = JSON.parse(localStorage.getItem("token") || "{}");
     const { config, response } = error;
 
     const status = response.status;
 
+    console.log(error);
     if (status === 400) {
-      const res = await axios({
+      const res = await client({
         method: "POST",
         url: "https://jobkok.shop/auth/reissue",
         headers: {


### PR DESCRIPTION
## 작업 개요 (이슈 번호)

## 작업 내용 (변경 사항)

- 미인증 시 발생하는 400에러를 해결하기 위해 interceptors 적용
  - 400 에러 발생시,  `interceptors.response`를 활용해 refreshToken으로 새로운 토큰 요청
  - 요청 성공시 `config.headers.Authorization`에 토큰 추가
  - 토큰 추가 후 `axios config` 적용후 return
  

## 리뷰 요청 사항
400 에러 발생되면 자동으로 토큰이 갱신되는 로직을 구현하였습니다. 에러나 수정사항 있으면 알려주세요.